### PR TITLE
Adding basic Vagrantfile.  Provisioner builds sioo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Steps to use this software in Vagrant
+# 1) Install VirtualBox
+# 2) Install Vagrant
+# 3) In project directory run 'vagrant up'
+# 4) vagrant ssh
+# 5) cd /SiOO
+# 6) Learn more at www.vagrantup.com
+
+$script = <<SCRIPT
+echo "Building.."
+cd /SiOO
+bash make-sioo
+SCRIPT
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/SiOO"
+  config.vm.provision "shell", inline: $script
+end


### PR DESCRIPTION
Currently builds fine.  Seems to run.  Is the issue here,
https://github.com/Sonophoto/sioo/issues/16#issuecomment-181690373
a bug in the code or is something not right about the Vagrantfile?  If its a bug then I'd say move this in as it will allow users of linux, mac and window to operate in a constant environment.  Changing the base box will allow testing against different platforms.
